### PR TITLE
auto join discovery room at registration using synapse parameter

### DIFF
--- a/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
+++ b/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
@@ -29,5 +29,7 @@ data:
             localpart_template: "{% raw %}{{ user.preferred_username }}{% endraw %}"
             display_name_template: "{% raw %}{{ user.name }}{% endraw %}"
         backchannel_logout_enabled: true # Optional
+    auto_join_rooms: ["#discoveryroom:{{ matrix.server_name }}"]
+    autocreate_auto_join_rooms: true
     app_service_config_files:
       - /data/msteams-registration.yaml


### PR DESCRIPTION
self explanatory.

---
Test : after deploying this modification, I registered a new user and checked that the discovery room was joined (using our discovery room scripts)