### PR TITLE
#145 close matrix federation

### DIFF
--- a/ansible/group_vars/env_vars.tmpl
+++ b/ansible/group_vars/env_vars.tmpl
@@ -43,8 +43,7 @@ matrix:
   dummy_username: ${DUMMY_USERNAME}
   dummy_password: ${DUMMY_PASSWORD}
   auto_registration: ${SYNAPSE_AUTO_REGISTRATION}
-  discovery_room:
-    servers_list: ${FEDERATION_SERVERS_LIST}
+  servers_list: ${FEDERATION_SERVERS_LIST}
 element:
   server_name: ${ELEMENT_SUBDOMAIN_NAME}.${ENVIRONMENT}.${DNS_ZONE}
 msteams:

--- a/ansible/roles/discovery-rooms/tasks/main.yml
+++ b/ansible/roles/discovery-rooms/tasks/main.yml
@@ -11,7 +11,7 @@
   ansible.builtin.import_tasks:
     file: join-discovery-room.yml
 
-- name: Dummy user joins external discovery rooms listed in matrix.discovery_room.servers_list
+- name: Dummy user joins external discovery rooms listed in matrix.servers_list
   uri:
     url: "http://{{ matrix.server_name }}/_matrix/client/r0/join/%23discoveryroom:{{ item }}"
     method: POST
@@ -23,5 +23,5 @@
     follow_redirects: all
     headers:
       Authorization: "Bearer {{ dummy_access_token }}"
-  loop: "{{ matrix.discovery_room.servers_list }}"
+  loop: "{{ matrix.servers_list }}"
   ignore_errors: true

--- a/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
+++ b/ansible/roles/synapse-extra-config/templates/cm-extraconfig.yml.j2
@@ -33,6 +33,9 @@ data:
 {% endif %}
     auto_join_rooms: ["#discoveryroom:{{ matrix.server_name }}"]
     autocreate_auto_join_rooms: true
+{% if matrix.servers_list is defined %}
+    federation_domain_whitelist: {{ matrix.servers_list }}
+{% endif %}
 {% if msteams.enabled %}  
     app_service_config_files:
       - /data/msteams-registration.yaml


### PR DESCRIPTION
## Description

Use [federation_domain_whitelist](https://matrix-org.github.io/synapse/develop/usage/configuration/config_documentation.html#federation_domain_whitelist) option to make EiMIS federation private.

#145

## Test
Tested on lagraulet env with 1 domain in the whitelist : it's not possible to contact anyone from outside whitelist.

## configuration

`FEDERATION_SERVERS_LIST` env parameter :

- **prod** not set
-  **preprod** set to `['matrix.develop.eimis.incubateur.net','matrix.pandalab.fr','api.mitest.mipih.fr ']`
-  **develop** set to `['matrix.preprod.eimis.incubateur.net','matrix.pandalab.fr','matrix.lagraulet.eimis.incubateur.net','matrix.matabiau.eimis.incubateur.net']`